### PR TITLE
add algorithm-option, set default hash algorithm to sha256

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Tokens accepts these properties in the options object.
 
 ##### algorithm
 
-The hash-algorithm to generate the token. Defaults to `sha1`.
+The hash-algorithm to generate the token. Defaults to `sha256`.
 
 ##### saltLength
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ optional and will just use all defaults if missing.
 
 Tokens accepts these properties in the options object.
 
+##### algorithm
+
+The hash-algorithm to generate the token. Defaults to `sha1`.
+
 ##### saltLength
 
 The length of the internal salt to use, in characters. Internally, the salt

--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ function Tokens (options) {
 
   const algorithm = opts.algorithm !== undefined
     ? opts.algorithm
-    : 'sha1'
+    : 'sha256'
 
   try {
     crypto

--- a/index.js
+++ b/index.js
@@ -28,6 +28,17 @@ function Tokens (options) {
 
   const opts = options || {}
 
+  const algorithm = opts.algorithm !== undefined
+    ? opts.algorithm
+    : 'sha1'
+
+  try {
+    crypto
+      .createHash(algorithm)
+  } catch (err) {
+    throw new TypeError('option algorithm must be a supported hash-algorithm')
+  }
+
   const saltLength = opts.saltLength !== undefined
     ? opts.saltLength
     : 8
@@ -60,6 +71,7 @@ function Tokens (options) {
     throw new TypeError('option userInfo must be a boolean')
   }
 
+  this.algorithm = algorithm
   this.saltLength = saltLength
   this.saltGenerator = saltGenerator(saltLength)
   this.secretLength = secretLength
@@ -88,7 +100,7 @@ Tokens.prototype.create = function create (secret, userInfo) {
     }
   }
 
-  return this._tokenize(secret, this.saltGenerator(), date, userInfo)
+  return this._tokenize(secret, this.saltGenerator(), date, userInfo, this.algorithm)
 }
 
 /**
@@ -186,7 +198,7 @@ Tokens.prototype.secretSync = Buffer.isEncoding('base64url')
  */
 
 Tokens.prototype._tokenize = Buffer.isEncoding('base64url')
-  ? function _tokenize (secret, salt, date, userInfo) {
+  ? function _tokenize (secret, salt, date, userInfo, algorithm) {
     let toHash = ''
 
     if (date !== null) {
@@ -195,7 +207,7 @@ Tokens.prototype._tokenize = Buffer.isEncoding('base64url')
 
     if (typeof userInfo === 'string') {
       toHash += crypto
-        .createHash('sha1')
+        .createHash(algorithm)
         .update(userInfo)
         .digest('base64url')
         .replace(MINUS_GLOBAL_REGEXP, '_') + '-'
@@ -204,11 +216,11 @@ Tokens.prototype._tokenize = Buffer.isEncoding('base64url')
     toHash += salt
 
     return toHash + '-' + crypto
-      .createHash('sha1')
+      .createHash(algorithm)
       .update(toHash + '-' + secret, 'ascii')
       .digest('base64url')
   }
-  : function _tokenize (secret, salt, date, userInfo) {
+  : function _tokenize (secret, salt, date, userInfo, algorithm) {
     let toHash = ''
 
     if (date !== null) {
@@ -217,7 +229,7 @@ Tokens.prototype._tokenize = Buffer.isEncoding('base64url')
 
     if (typeof userInfo === 'string') {
       toHash += crypto
-        .createHash('sha1')
+        .createHash(algorithm)
         .update(userInfo)
         .digest('base64')
         .replace(PLUS_SLASH_GLOBAL_REGEXP, '_')
@@ -227,7 +239,7 @@ Tokens.prototype._tokenize = Buffer.isEncoding('base64url')
     toHash += salt
 
     return toHash + '-' + crypto
-      .createHash('sha1')
+      .createHash(algorithm)
       .update(toHash + '-' + secret, 'ascii')
       .digest('base64')
       .replace(PLUS_GLOBAL_REGEXP, '-')
@@ -294,7 +306,7 @@ Tokens.prototype.verify = function verify (secret, token, userInfo) {
   const salt = token.slice(curIdx, nextIdx)
 
   const actual = Buffer.from(token)
-  const expected = Buffer.from(this._tokenize(secret, salt, date, userInfo))
+  const expected = Buffer.from(this._tokenize(secret, salt, date, userInfo, this.algorithm))
 
   // to avoid the exposure if the provided value has the correct length, we call
   // timingSafeEqual with the actual value. The additional length check itself is

--- a/test/constructor.test.js
+++ b/test/constructor.test.js
@@ -57,3 +57,8 @@ test('Tokens.constructor: instantiating Tokens without new creates still the Tok
   t.plan(1)
   t.ok(Tokens() instanceof Tokens, true)
 })
+
+test('Tokens.constructor: instantiating Tokens with "invalid" for algorithm should throw', t => {
+  t.plan(1)
+  t.throws(() => new Tokens({ algorithm: 'invalid' }), new TypeError('option algorithm must be a supported hash-algorithm'))
+})

--- a/test/create.test.js
+++ b/test/create.test.js
@@ -34,7 +34,7 @@ test('Tokens.create: should always be the same length', t => {
   const secret = new Tokens().secretSync()
   const tokenLength = new Tokens().create(secret).length
 
-  t.equal(tokenLength, 36)
+  t.equal(tokenLength, 52)
 
   for (let i = 0; i < 1000; i++) {
     t.equal(new Tokens().create(secret).length, tokenLength)

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -123,22 +123,22 @@ test('.create() and verify() with user info: should return false for edge case',
   t.equal(new Tokens({ userInfo: true }).verify(secret, token, 'foo'), false)
 })
 
-test('.create() and verify() with validity: should use by default sha1', t => {
+test('.create() and verify() with validity: should use by default sha256 as algorithm', t => {
   t.plan(2)
 
   const secret = new Tokens().secretSync()
   const token = new Tokens({ userInfo: true }).create(secret, 'foobar')
 
-  t.equal(token.length, 64)
-  t.equal(new Tokens({ userInfo: true, algorithm: 'sha1' }).verify(secret, token, 'foobar'), true)
+  t.equal(token.length, 96)
+  t.equal(new Tokens({ userInfo: true, algorithm: 'sha256' }).verify(secret, token, 'foobar'), true)
 })
 
-test('.create() and verify() with validity: should return `false` for edge case', t => {
+test('.create() and verify() with validity: should be able to set sha1 as algorithm', t => {
   t.plan(2)
 
   const secret = new Tokens().secretSync()
-  const token = new Tokens({ userInfo: true, algorithm: 'sha256' }).create(secret, 'foobar')
+  const token = new Tokens({ userInfo: true, algorithm: 'sha1' }).create(secret, 'foobar')
 
-  t.equal(token.length, 96)
-  t.equal(new Tokens({ userInfo: true, algorithm: 'sha256' }).verify(secret, token, 'foobar'), true)
+  t.equal(token.length, 64)
+  t.equal(new Tokens({ userInfo: true, algorithm: 'sha1' }).verify(secret, token, 'foobar'), true)
 })

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -122,3 +122,23 @@ test('.create() and verify() with user info: should return false for edge case',
 
   t.equal(new Tokens({ userInfo: true }).verify(secret, token, 'foo'), false)
 })
+
+test('.create() and verify() with validity: should use by default sha1', t => {
+  t.plan(2)
+
+  const secret = new Tokens().secretSync()
+  const token = new Tokens({ userInfo: true }).create(secret, 'foobar')
+
+  t.equal(token.length, 64)
+  t.equal(new Tokens({ userInfo: true, algorithm: 'sha1' }).verify(secret, token, 'foobar'), true)
+})
+
+test('.create() and verify() with validity: should return `false` for edge case', t => {
+  t.plan(2)
+
+  const secret = new Tokens().secretSync()
+  const token = new Tokens({ userInfo: true, algorithm: 'sha256' }).create(secret, 'foobar')
+
+  t.equal(token.length, 96)
+  t.equal(new Tokens({ userInfo: true, algorithm: 'sha256' }).verify(secret, token, 'foobar'), true)
+})

--- a/test/secret.test.js
+++ b/test/secret.test.js
@@ -79,7 +79,8 @@ test('Tokens.secret: should handle error, Promise', t => {
     crypto: {
       randomBytes: (_size, cb) => {
         cb(new Error('oh no'))
-      }
+      },
+      createHash: require('crypto').createHash
     }
   })
 
@@ -96,7 +97,8 @@ test('Tokens.secret: should handle error, callback', t => {
     crypto: {
       randomBytes: (size, cb) => {
         cb(new Error('oh no'))
-      }
+      },
+      createHash: require('crypto').createHash
     }
   })
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -40,7 +40,7 @@ export type SecretCallback = (err: Error | null, secret: string) => void;
 export interface Options {
   /**
    * The algorithm used to generate the token
-   * @default sha1
+   * @default sha256
    */
   algorithm?: string;
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -39,6 +39,12 @@ export type SecretCallback = (err: Error | null, secret: string) => void;
 
 export interface Options {
   /**
+   * The algorithm used to generate the token
+   * @default sha1
+   */
+  algorithm?: string;
+
+  /**
    * The string length of the salt
    * 
    * @default 8

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -5,6 +5,8 @@ Tokens();
 new Tokens();
 Tokens({});
 new Tokens({});
+Tokens({ algorithm: 'sha1' });
+Tokens({ algorithm: 'sha256' });
 Tokens({ saltLength: 10 });
 Tokens({ secretLength: 10 });
 Tokens({ userInfo: true });


### PR DESCRIPTION
Motivated by the latest csurf sec. vuln. 

snyk writes regarding csurf:

> In particular, it doesn’t properly validate cookie values for the double submit cookie pattern, which results in attackers being able to spoof the CSRF token. Adding to the problem, it relies on a deprecated encryption algorithm (SHA1) for hashing CSRF tokens.

https://snyk.io/blog/explaining-the-csurf-vulnerability-csrf-attacks-on-all-versions/

I personally think sha1 or sha256 or whatever does not make a big difference as csrf is actually shortlived so there is no time to crack it actually. But this PR adds anyway the algorithm option. 

It sets sha256 as default hash algorithm. It would be a breaking change, but people could upgrade and set the algorithm back to sha1 if they still want to use sha1.

It this gets merged, there would be a follow up PR for the csrf-protection package.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
