### PR TITLE
feat: support hmac

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,10 @@ bytes, not the length of the base-64 string. Defaults to `18` bytes.
 Require user-specific information in `tokens.create()` and
 `tokens.verify()`.
 
+##### hmacKey
+
+The HMAC key used to generate the cryptographic HMAC hash.
+
 ##### validity
 
 The maximum validity of the token to generate, in milliseconds. Note that the epoch  is

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Require user-specific information in `tokens.create()` and
 
 ##### hmacKey
 
-The HMAC key used to generate the cryptographic HMAC hash.
+When set, the `hmacKey` is used to generate the cryptographic HMAC hash instead of the default hash function.
 
 ##### validity
 

--- a/index.js
+++ b/index.js
@@ -75,7 +75,8 @@ function Tokens (options) {
 
   if (hmacKey) {
     try {
-      crypto.createHmac(algorithm, hmacKey)
+      // validate if the hmacKey is a valid format
+      hashingStrategy(algorithm, hmacKey)
     } catch (err) {
       throw new TypeError('option hmacKey must be a supported hmac key')
     }

--- a/index.js
+++ b/index.js
@@ -77,7 +77,7 @@ function Tokens (options) {
     try {
       crypto.createHmac(algorithm, hmacKey)
     } catch (err) {
-      throw new TypeError('option hmacKey must be a support hmac key')
+      throw new TypeError('option hmacKey must be a supported hmac key')
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "test:typescript": "tsd"
   },
   "devDependencies": {
+    "@types/node": "^18.14.6",
     "beautify-benchmark": "^0.2.4",
     "benchmark": "^2.1.4",
     "standard": "^17.0.0",

--- a/test/hmac.test.js
+++ b/test/hmac.test.js
@@ -5,7 +5,7 @@ const Tokens = require('..')
 
 test('Tokens.constructor: instantiating Tokens with a non string hmacKey should throw', t => {
   t.plan(1)
-  t.throws(() => new Tokens({ hmacKey: 123 }), new TypeError('option hmacKey must be a support hmac key'))
+  t.throws(() => new Tokens({ hmacKey: 123 }), new TypeError('option hmacKey must be a supported hmac key'))
 })
 
 test('Tokens.secret: should create a secret', t => {

--- a/test/hmac.test.js
+++ b/test/hmac.test.js
@@ -1,0 +1,63 @@
+'use strict'
+
+const test = require('tap').test
+const Tokens = require('..')
+
+test('Tokens.constructor: instantiating Tokens with a non string hmacKey should throw', t => {
+  t.plan(1)
+  t.throws(() => new Tokens({ hmacKey: 123 }), new TypeError('option hmacKey must be a support hmac key'))
+})
+
+test('Tokens.secret: should create a secret', t => {
+  t.plan(3)
+
+  new Tokens({ hmacKey: 'foo' }).secret(function (err, secret) {
+    t.error(err)
+    t.type(secret, 'string')
+    t.equal(secret.length, 24)
+  })
+})
+
+test('Tokens.verify: should return `true` with valid tokens', t => {
+  t.plan(1)
+
+  const secret = new Tokens({ hmacKey: 'foo' }).secretSync()
+  const token = new Tokens({ hmacKey: 'foo' }).create(secret)
+
+  t.equal(new Tokens({ hmacKey: 'foo' }).verify(secret, token), true)
+})
+
+test('Tokens.verify: should return `false` with invalid secret', t => {
+  t.plan(5)
+
+  const secret = new Tokens({ hmacKey: 'foo' }).secretSync()
+  const token = new Tokens({ hmacKey: 'foo' }).create(secret)
+
+  t.equal(new Tokens({ hmacKey: 'foo' }).verify(new Tokens().secretSync(), token), false)
+  t.equal(new Tokens({ hmacKey: 'foo' }).verify('invalid', token), false)
+  t.equal(new Tokens({ hmacKey: 'foo' }).verify(), false)
+  t.equal(new Tokens({ hmacKey: 'foo' }).verify([]), false)
+  t.equal(new Tokens({ hmacKey: 'foo' }).verify('invalid'), false)
+})
+
+test('Tokens.verify: should return `false` with invalid tokens', t => {
+  t.plan(4)
+
+  const secret = new Tokens({ hmacKey: 'foo' }).secretSync()
+  const token = new Tokens({ hmacKey: 'foo' }).create(secret)
+
+  t.equal(new Tokens({ hmacKey: 'foo' }).verify('invalid', token), false)
+  t.equal(new Tokens({ hmacKey: 'foo' }).verify(secret, undefined), false)
+  t.equal(new Tokens({ hmacKey: 'foo' }).verify(secret, []), false)
+  t.equal(new Tokens({ hmacKey: 'foo' }).verify(secret, 'hi'), false)
+})
+
+test('Tokens.verify: should return `false` with different hmac key', t => {
+  t.plan(2)
+
+  const secret = new Tokens({ hmacKey: 'foo' }).secretSync()
+  const token = new Tokens({ hmacKey: 'foo' }).create(secret)
+
+  t.equal(new Tokens({ hmacKey: 'foo' }).verify(secret, token), true)
+  t.equal(new Tokens({ hmacKey: 'bar' }).verify(secret, token), false)
+})

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -79,11 +79,28 @@ declare namespace Tokens {
      * @default false
      */
     userInfo?: boolean;
+
+    /**
+     * The HMAC key used to generate the cryptographic HMAC hash
+     * 
+     */
+    hmacKey?: string | ArrayBuffer | Buffer | TypedArray | DataView | CryptoKey;
   }
 
   export const Tokens: TokensConstructor
   export { Tokens as default }
 }
+
+type TypedArray =
+  | Int8Array
+  | Uint8Array
+  | Uint8ClampedArray
+  | Int16Array
+  | Uint16Array
+  | Int32Array
+  | Uint32Array
+  | Float32Array
+  | Float64Array;
 
 declare function Tokens(...params: Parameters<TokensConstructor>): ReturnType<TokensConstructor>
 export = Tokens

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -11,6 +11,7 @@ Tokens({ saltLength: 10 });
 Tokens({ secretLength: 10 });
 Tokens({ userInfo: true });
 Tokens({ validity: 10000 });
+Tokens({ hmacKey: 'foo' });
 new Tokens({ saltLength: 10 });
 new Tokens({ secretLength: 10 });
 new Tokens({ userInfo: true });
@@ -26,6 +27,8 @@ expectError(new Tokens({ userInfo: true }).create('secret'));
 expectError(new Tokens({}).verify('secret', 'token', 'userinfo'));
 expectError(new Tokens({ userInfo: false}).verify('secret', 'token', 'userInfo'));
 expectError(new Tokens({ userInfo: true }).verify('secret', 'token'));
+
+expectError(new Tokens({ hmacKey: 123 }));
 
 expectType<Promise<string>>(Tokens().secret());
 expectType<Promise<string>>(new Tokens().secret());


### PR DESCRIPTION
I've created this pr to support hmac.
(I included @types/node in order to use `Buffer` in `hmacKey` in types)
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
