### PR TITLE
perf: use `node:` prefix to bypass require.cache call for builtins

### DIFF
--- a/benchmark/create.js
+++ b/benchmark/create.js
@@ -1,4 +1,3 @@
-
 /**
  * Module dependencies.
  */

--- a/benchmark/index.js
+++ b/benchmark/index.js
@@ -1,6 +1,6 @@
-const fs = require('fs')
-const path = require('path')
-const spawn = require('child_process').spawn
+const fs = require('node:fs')
+const path = require('node:path')
+const spawn = require('node:child_process').spawn
 
 const exe = process.argv[0]
 const cwd = process.cwd()

--- a/benchmark/secret.js
+++ b/benchmark/secret.js
@@ -1,4 +1,3 @@
-
 /**
  * Module dependencies.
  */

--- a/benchmark/verify.js
+++ b/benchmark/verify.js
@@ -1,4 +1,3 @@
-
 /**
  * Module dependencies.
  */

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@
  * MIT Licensed
  */
 
-const crypto = require('crypto')
+const crypto = require('node:crypto')
 
 /**
  * Token generation/verification class.

--- a/test/secret.test.js
+++ b/test/secret.test.js
@@ -80,7 +80,7 @@ test('Tokens.secret: should handle error, Promise', t => {
       randomBytes: (_size, cb) => {
         cb(new Error('oh no'))
       },
-      createHash: require('crypto').createHash
+      createHash: require('node:crypto').createHash
     }
   })
 
@@ -98,7 +98,7 @@ test('Tokens.secret: should handle error, callback', t => {
       randomBytes: (size, cb) => {
         cb(new Error('oh no'))
       },
-      createHash: require('crypto').createHash
+      createHash: require('node:crypto').createHash
     }
   })
 

--- a/test/secret.test.js
+++ b/test/secret.test.js
@@ -76,7 +76,7 @@ test('Tokens.secret: should handle error, Promise', t => {
   t.plan(2)
 
   const Tokens = mock('..', {
-    crypto: {
+    'node:crypto': {
       randomBytes: (_size, cb) => {
         cb(new Error('oh no'))
       },
@@ -94,7 +94,7 @@ test('Tokens.secret: should handle error, callback', t => {
   t.plan(2)
 
   const Tokens = mock('..', {
-    crypto: {
+    'node:crypto': {
       randomBytes: (size, cb) => {
         cb(new Error('oh no'))
       },


### PR DESCRIPTION
See https://github.com/fastify/fastify-static/pull/407

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
