### PR TITLE
build(deps-dev): add eslint, peer dep of neostandard

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@types/node": "^22.0.0",
     "beautify-benchmark": "^0.2.4",
     "benchmark": "^2.1.4",
+    "eslint": "^9.17.0",
     "neostandard": "^0.12.0",
     "tap": "^18.7.1",
     "tsd": "^0.31.0"


### PR DESCRIPTION
Missing peer dep. This is a batch PR, so may have some issues. Please review changes.